### PR TITLE
Bug/fix title in team pages

### DIFF
--- a/_includes/news.html
+++ b/_includes/news.html
@@ -221,7 +221,7 @@
       // Auto-advance slides every 5 seconds
       setInterval(() => {
         moveToSlide(currentSlide + 1);
-      }, 5000);
+      }, 15000);
     });
   </script>
 </div>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -4,13 +4,20 @@ layout: default
 
 <!-- about.html -->
       <div class="post">
-        <header class="post-header">
-          <h1 class="post-title">
-           {% if site.title == "blank" -%}<span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }} {{ site.last_name }}{%- else -%}{{ site.title }}{%- endif %}
-          </h1>
-          <p class="desc">{{ page.subtitle }}</p>
-        </header>
-
+        
+        <!-- The block below was replaced to dynamically use the page title or fall back to the site title -->
+        <h1 class="post-title">
+          {{ page.title | default: site.title }}
+        </h1>
+        <!-- Original block:
+        <h1 class="post-title">
+          {% if site.title == "blank" -%}
+            <span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }} {{ site.last_name }}
+          {%- else -%}
+            {{ site.title }}
+          {%- endif %}
+        </h1>
+        -->
         <article>
           {% if page.profile -%}
           <div class="profile float-{%- if page.profile.align == 'left' -%}left{%- else -%}right{%- endif -%}">


### PR DESCRIPTION
# Fix Dynamic Title Logic in `about.html` Layout

## Description

This PR resolves an issue in the `about.html` layout where the title for pages using this layout was hardcoded or derived solely from `site.title`. As a result, all pages (e.g., member profiles) displayed the same title, ignoring the `title` field specified in the front matter.

### Changes Made
- Replaced the hardcoded `<h1>` logic with dynamic rendering:
  - The layout now prioritizes `page.title` from the front matter.
  - Falls back to `site.title` when `page.title` is not defined.
- Simplified the code to improve maintainability and clarity.
- Added inline comments to document the fix and the original issue.

### Impact
- Each page now displays its unique `title` (e.g., "Abdulfattah Rashid Safa" for individual member profiles).
- Static pages using the layout also fall back to the `site.title` when no `title` is provided.
- Aligns with Jekyll best practices for dynamic and reusable layouts.

---

## Before and After

### Before:
- All pages displayed the same title (e.g., derived from `site.title` which was `GGLab`).

### After:
- Pages dynamically render their unique `title` field from the front matter.

---

## Testing
- Verified member profile pages correctly display the `title` from their front matter.
- Tested fallback behavior to `site.title` for pages without a `title` field.

---
![image](https://github.com/user-attachments/assets/0c4f0580-f049-4bcf-9f1b-c0e358848a50)

# Minor Fix
- The interval of the sliding window is being increased to 15 seconds to provide readers with enough time to read individual news items.
