### PR TITLE
Remove malicious polyfill.io script - was serving malware since Feb 2024

### DIFF
--- a/_includes/scripts/mathjax.html
+++ b/_includes/scripts/mathjax.html
@@ -8,5 +8,4 @@
     };
   </script>
   <script defer type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js"></script>
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   {%- endif %}


### PR DESCRIPTION
The polyfill.io service was compromised and is no longer safe. Additionally, modern browsers fully support ES6 natively, so the polyfill is not needed. MathJax already provides ES5 output via tex-mml-chtml.js.

Fixes #67